### PR TITLE
Fix fingerprint detection for some Oplus devices

### DIFF
--- a/extract_and_push.sh
+++ b/extract_and_push.sh
@@ -364,9 +364,9 @@ manufacturer=$(grep -m1 -oP "(?<=^ro.product.manufacturer=).*" -hs odm/etc/finge
 [[ -z ${manufacturer} ]] && manufacturer=$(grep -m1 -oP "(?<=^ro.product.product.manufacturer=).*" -hs vendor/euclid/product/build*.prop)
 manufacturer=$(echo "$manufacturer" | head -1)
 
-fingerprint=$(grep -m1 -oP "(?<=^ro.vendor.build.fingerprint=).*" -hs odm/etc/fingerprint/build.default.prop)
-[[ -z ${fingerprint} ]] && fingerprint=$(grep -m1 -oP "(?<=^ro.vendor.build.fingerprint=).*" -hs my_manifest/build*.prop)
+fingerprint=$(grep -m1 -oP "(?<=^ro.vendor.build.fingerprint=).*" -hs my_manifest/build*.prop)
 [[ -z ${fingerprint} ]] && fingerprint=$(grep -m1 -oP "(?<=^ro.vendor.build.fingerprint=).*" -hs vendor/euclid/my_manifest/build.prop)
+[[ -z ${fingerprint} ]] && fingerprint=$(grep -m1 -oP "(?<=^ro.vendor.build.fingerprint=).*" -hs odm/etc/fingerprint/build.default.prop)
 [[ -z ${fingerprint} ]] && fingerprint=$(grep -m1 -oP "(?<=^ro.vendor.build.fingerprint=).*" -hs vendor/build*.prop)
 [[ -z ${fingerprint} ]] && fingerprint=$(grep -m1 -oP "(?<=^ro.build.fingerprint=).*" -hs my_manifest/build*.prop)
 [[ -z ${fingerprint} ]] && fingerprint=$(grep -m1 -oP "(?<=^ro.build.fingerprint=).*" -hs vendor/euclid/my_manifest/build.prop)


### PR DESCRIPTION
The OnePlus Nord CE 3 Lite EUEX build is currently reported to have a fingerprint of `OnePlus/CPH2467/OP5958L1:13/RKQ1.211119.001/T.R4T2.f9e513-4-11c2:user/release-keys`

This is incorrect, as it is `OnePlus/CPH2465EEA/OP5958L1:13/RKQ1.211119.001/T.R4T2.f9e513-4-11c2:user/release-keys` (my_manifest build.prop contains the accurate properties).

Test: dump https://gauss-componentotacostmanual-sg.allawnofs.com/remove-427f165c3dff1ccdec98c7056244660a/component-ota/23/04/12/981053e4ae704af1a4449f42473c6aeb.zip