### PR TITLE
extract_and_push: Only use pixeldrain mirror for legacy URLs

### DIFF
--- a/extract_and_push.sh
+++ b/extract_and_push.sh
@@ -165,7 +165,7 @@ else
             fi
         ;;
         # For Pixeldrain: replace the link with a direct one
-        *"pixeldrain.com"*)
+        *"pixeldrain.com/u"*)
             echo "[INFO] Replacing with best available mirror."
             URL="https://pd.cybar.xyz/${URL##*/}"
         ;;


### PR DESCRIPTION
- While we are at it use DDL for pixeldrain filesystem as well