### PR TITLE
extract_and_push.sh: Extract recovery.img

### DIFF
--- a/extract_and_push.sh
+++ b/extract_and_push.sh
@@ -370,6 +370,37 @@ if [[ -f "${PWD}/boot.img" ]]; then
         fi
     fi
 
+# Extract 'recovery.img'
+if [[ -f "${PWD}/recovery.img" ]]; then
+    # Set a variable for each path
+    ## Image
+    IMAGE=${PWD}/recovery.img
+
+    ## Output
+    OUTPUT=${PWD}/recovery
+
+    # Python rewrite automatically extracts such partitions
+    if [[ "${USE_ALT_DUMPER}" == "true" ]]; then
+        mkdir -p "${OUTPUT}/ramdisk"
+
+        # Unpack 'recovery.img' through 'unpackbootimg'
+        echo "[INFO] Extracting 'recovery.img' content..."
+        ${UNPACKBOOTIMG} -i "${IMAGE}" -o "${OUTPUT}" > /dev/null || \
+            echo "[ERROR] Extraction unsuccessful."
+
+        # Decrompress 'recovery.img-ramdisk'
+        ## Run only if 'recovery.img-ramdisk' is not empty
+        if file recovery.img-ramdisk | grep -q LZ4 || file recovery.img-ramdisk | grep -q gzip; then
+            echo "[INFO] Extracting ramdisk..."
+            unlz4 "${OUTPUT}/recovery.img-ramdisk" "${OUTPUT}/ramdisk.lz4" > /dev/null
+            7zz -snld x "${OUTPUT}/ramdisk.lz4" -o"${OUTPUT}/ramdisk" > /dev/null || \
+                echo "[ERROR] Failed to extract ramdisk."
+
+            ## Clean-up
+            rm -rf "${OUTPUT}/ramdisk.lz4"
+        fi
+    fi
+
     # Extract 'ikconfig'
     echo "[INFO] Extract 'ikconfig'..."
     if command -v extract-ikconfig > /dev/null ; then


### PR DESCRIPTION
This pull request adds support for extracting the `recovery.img` partition in the `extract_and_push.sh` script, following the existing logic for `boot.img`. The new logic ensures that `recovery.img` is unpacked and its ramdisk is extracted when the alternative dumper is enabled.

**New recovery image extraction:**

* Added logic to detect and extract `recovery.img` if present, including setting up output directories and unpacking the image using `unpackbootimg`.
* Implemented ramdisk extraction for `recovery.img` when compressed with LZ4 or gzip, using `unlz4` and `7zz`, and included clean-up of intermediate files.