### PR TITLE
extract_and_push: Remove pixeldrain proxy

### DIFF
--- a/extract_and_push.sh
+++ b/extract_and_push.sh
@@ -177,7 +177,7 @@ else
         # For Pixeldrain: replace the link with a direct one
         *"pixeldrain.com/u"*)
             echo "[INFO] Replacing with best available mirror."
-            URL="https://pd.cybar.xyz/${URL##*/}"
+            URL="https://pixeldrain.com/api/file/${URL##*/}"
         ;;
         *"pixeldrain.com/d"*)
             echo "[INFO] Replacing with direct download link."


### PR DESCRIPTION
All of the proxies have been killed for quite some time. Un-break pixeldrain downloads